### PR TITLE
remove resize = false

### DIFF
--- a/make_nd_dataset.py
+++ b/make_nd_dataset.py
@@ -285,10 +285,11 @@ else:
 
 szs = np.vstack(szs)[:,0]
 
-if len(np.unique(szs))>1:
-    do_resize=True
-else:
-    do_resize=False
+do_resize = True
+# if len(np.unique(szs))>1:
+#     do_resize=True
+# else:
+#     do_resize=False
 
 ## rersize / pad imagery so all a consistent size (TARGET_SIZE)
 if do_resize:


### PR DESCRIPTION
I think i found an edge case where - if images are all the same size, then resizing (and no padding occurs). this messes with tensor shapes if the images are resized to a different target size. This PR removes the if/else statement an *always* resizes images. (`do_resize = True`). 

There are other solutions, such as putting the resize flag in the config (default would be do_resize = True, but user could set it to false in the very rare circumstance that their images are the exact size as the target size. 

This PR does not necessarily need to be merged - i.e., we could implement another solution - but i do want to bring this issue up. 