### PR TITLE
New makedatasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ DOI](https://img.shields.io/badge/%F0%9F%8C%8D%F0%9F%8C%8F%F0%9F%8C%8E%20EarthAr
 ## 🌟 Highlights
 
 - Gym is for training, evaluating, and deploying deep learning models for image segmentation
-- We take transferability seriously; Gym is designed to be a "one stop shop" for image segmentation on N-D imagery (i.e. any number of coincident bands). It is tailored to Earth Observation and aerial remote sensing imagery.
+- We take transferability seriously; Gym is designed to be a "one stop shop" for image segmentation on "N-D" imagery (i.e. any number of coincident bands in a multispectral image). It is tailored to Earth Observation and aerial remote sensing imagery.
 - Gym encodes relatively powerful models like UNets, and provides lots of ways to manipulate data, model training, and model architectures that should yield good results with some informed experimentation
 - Gym works seamlessly with [Doodler](https://github.com/Doodleverse/dash_doodler), a human-in-the loop labeling tool that will help you make training data for Gym. 
 - It would also work on any imagery in jpg or png format that has corresponding 2d greyscale integer label images (jpg or png), however acquired.
@@ -97,7 +97,7 @@ conda env create --file install/gym.yml
 conda activate gym
 ```
 
-Alternatively, you could install using mamba, which should be significantly faster
+[ADVANCED] Alternatively, you could install using mamba, which could be significantly faster
 
 ```
 conda install mamba -c conda-forge

--- a/batch_seg_images_in_folders.py
+++ b/batch_seg_images_in_folders.py
@@ -266,97 +266,19 @@ for sample_direc in folders:
 
     print('Number of samples: %i' % (len(sample_filenames)))
 
+
     #look for TTA config
     if not 'TESTTIMEAUG' in locals():
         TESTTIMEAUG = False
+    #look for do_crf in config
+    if not 'do_crf' in locals():
+        do_crf = False
+    if not 'WRITE_MODELMETADATA' in locals():
+        WRITE_MODELMETADATA = False
 
+    # Import do_seg() from doodleverse_utils to perform the segmentation on the images
     for f in tqdm(sample_filenames):
         try:
             do_seg(f, M, metadatadict, sample_direc,NCLASSES,N_DATA_BANDS,TARGET_SIZE,TESTTIMEAUG, WRITE_MODELMETADATA,do_crf)
         except:
             print("{} failed".format(f))
-
-
-
-#####################################
-#### editable variables
-####################################
-# do_crf = True
-
-# USE_GPU = True
-# USE_GPU = False
-
-## edit to set GPU number
-# SET_GPU = 0
-
-## to store interim model outputs and metadata, use True
-# WRITE_MODELMETADATA = False 
-
-# #####################################
-# #### hardware
-# ####################################
-
-# SET_GPU = str(SET_GPU)
-
-# if SET_GPU != '-1':
-#     USE_GPU = True
-#     print('Using GPU')
-# else:
-#     USE_GPU = False
-
-# if len(SET_GPU.split(','))>1:
-#     USE_MULTI_GPU = True 
-#     print('Using multiple GPUs')
-# else:
-#     USE_MULTI_GPU = False
-#     if USE_GPU:
-#         print('Using single GPU device')
-#     else:
-#         print('Using single CPU device')
-
-# #suppress tensorflow warnings
-# os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-
-# if USE_GPU == True:
-#     os.environ['CUDA_VISIBLE_DEVICES'] = SET_GPU
-
-#     from doodleverse_utils.prediction_imports import *
-#     from tensorflow.python.client import device_lib
-#     physical_devices = tf.config.experimental.list_physical_devices('GPU')
-#     print(physical_devices)
-
-#     if physical_devices:
-#         # Restrict TensorFlow to only use the first GPU
-#         try:
-#             tf.config.experimental.set_visible_devices(physical_devices, 'GPU')
-#         except RuntimeError as e:
-#             # Visible devices must be set at program startup
-#             print(e)
-# else:
-#     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
-
-#     from doodleverse_utils.prediction_imports import *
-#     from tensorflow.python.client import device_lib
-#     physical_devices = tf.config.experimental.list_physical_devices('GPU')
-#     print(physical_devices)
-
-# ### mixed precision
-# from tensorflow.keras import mixed_precision
-# mixed_precision.set_global_policy('mixed_float16')
-# # tf.debugging.set_log_device_placement(True)
-
-# for i in physical_devices:
-#     tf.config.experimental.set_memory_growth(i, True)
-# print(tf.config.get_visible_devices())
-
-# if USE_MULTI_GPU:
-#     # Create a MirroredStrategy.
-#     strategy = tf.distribute.MirroredStrategy([p.name.split('/physical_device:')[-1] for p in physical_devices], cross_device_ops=tf.distribute.HierarchicalCopyAllReduce())
-#     print("Number of distributed devices: {}".format(strategy.num_replicas_in_sync))
-
-#####################################
-#### session variables
-####################################
-
-
-# from prediction_imports import *

--- a/make_nd_dataset.py
+++ b/make_nd_dataset.py
@@ -72,39 +72,41 @@ def scale_rgb(img, nR, nC, nD):
 def do_pad_label(lfile, TARGET_SIZE):
     ### labels ------------------------------------
     lab = imread(lfile)
+    result = scale(lab,TARGET_SIZE[0],TARGET_SIZE[1])
 
-    try:
-        old_image_height, old_image_width, channels = lab.shape
-    except:
-        old_image_height, old_image_width = lab.shape
-        channels=0
+    # try:
+    #     old_image_height, old_image_width, channels = lab.shape
+    # except:
+    #     old_image_height, old_image_width = lab.shape
+    #     channels=0
 
-    # create new image of desired size and color (black) for padding
-    new_image_width = TARGET_SIZE[0]
-    new_image_height = TARGET_SIZE[0]
+    # # create new image of desired size and color (black) for padding
+    # new_image_width = TARGET_SIZE[0]
+    # new_image_height = TARGET_SIZE[0]
 
-    # compute center offset
-    x_center = (new_image_width - old_image_width) // 2
-    y_center = (new_image_height - old_image_height) // 2
+    # # compute center offset
+    # x_center = (new_image_width - old_image_width) // 2
+    # y_center = (new_image_height - old_image_height) // 2
 
-    color = (0)
-    result = np.full((new_image_height,new_image_width), color, dtype=np.uint8)
+    # color = (0)
+    # result = np.full((new_image_height,new_image_width), color, dtype=np.uint8)
 
-    try: #image is smaller
-        # copy img image into center of result image
-        result[y_center:y_center+old_image_height,
-               x_center:x_center+old_image_width] = lab+1
-    except:
-        result = scale(lab,TARGET_SIZE[0],TARGET_SIZE[1])+1
+    # try: #image is smaller
+    #     # copy img image into center of result image
+    #     result[y_center:y_center+old_image_height,
+    #            x_center:x_center+old_image_width] = lab+1
+    # except:
+    #     result = scale(lab,TARGET_SIZE[0],TARGET_SIZE[1])+1
 
-        ##lab2 =rescale(lab,(sf,sf),anti_aliasing=True, preserve_range=True, order=0)
-        # result[y_center:y_center+old_image_height,
-        #        x_center:x_center+old_image_width] = lab2+1
-        # del lab2
+    #     ##lab2 =rescale(lab,(sf,sf),anti_aliasing=True, preserve_range=True, order=0)
+    #     # result[y_center:y_center+old_image_height,
+    #     #        x_center:x_center+old_image_width] = lab2+1
+    #     # del lab2
 
     wend = lfile.split(os.sep)[-2]
     fdir = os.path.dirname(lfile)
-    fdirout = fdir.replace(wend,'padded_'+wend)
+    # fdirout = fdir.replace(wend,'padded_'+wend)
+    fdirout = fdir.replace(wend,'resized_'+wend)
 
     # save result
     #imsave(lfile.replace('labels','padded_labels').replace('.jpg','.png'), result.astype('uint8'), check_contrast=False, compression=0)
@@ -121,49 +123,56 @@ def do_pad_image(f, TARGET_SIZE):
         old_image_height, old_image_width = img.shape
         channels=0
 
-    # create new image of desired size and color (black) for padding
-    new_image_width = TARGET_SIZE[0]
-    new_image_height = TARGET_SIZE[0]
     if channels>0:
-        color = (0,0,0)
-        result = np.full((new_image_height,new_image_width, channels), color, dtype=np.uint8)
+        result = scale_rgb(img,TARGET_SIZE[0],TARGET_SIZE[1],3)
     else:
-        color = (0)
-        result = np.full((new_image_height,new_image_width), color, dtype=np.uint8)
+        result = scale(img,TARGET_SIZE[0],TARGET_SIZE[1])
 
-    # compute center offset
-    x_center = (new_image_width - old_image_width) // 2
-    y_center = (new_image_height - old_image_height) // 2
+    # # create new image of desired size and color (black) for padding
+    # new_image_width = TARGET_SIZE[0]
+    # new_image_height = TARGET_SIZE[0]
+    # if channels>0:
+    #     color = (0,0,0)
+    #     result = np.full((new_image_height,new_image_width, channels), color, dtype=np.uint8)
+    # else:
+    #     color = (0)
+    #     result = np.full((new_image_height,new_image_width), color, dtype=np.uint8)
 
-    try:
-        # copy img image into center of result image
-        result[y_center:y_center+old_image_height,
-               x_center:x_center+old_image_width] = img
-    except:
-        ## AN ALTERNATIVE WAY - DO NOT REMOVE
-        # sf = np.minimum(new_image_width/old_image_width,new_image_height/old_image_height)
-        # if channels>0:
-        #     img = rescale(img,(sf,sf,1),anti_aliasing=True, preserve_range=True, order=1)
-        # else:
-        #     img = rescale(img,(sf,sf),anti_aliasing=True, preserve_range=True, order=1)
-        # if channels>0:
-        #     old_image_height, old_image_width, channels = img.shape
-        # else:
-        #     old_image_height, old_image_width = img.shape
-        #
-        # x_center = (new_image_width - old_image_width) // 2
-        # y_center = (new_image_height - old_image_height) // 2
-        #
-        # result[y_center:y_center+old_image_height,
-        #        x_center:x_center+old_image_width] = img.astype('uint8')
-        if channels>0:
-            result = scale_rgb(img,TARGET_SIZE[0],TARGET_SIZE[1],3)
-        else:
-            result = scale(img,TARGET_SIZE[0],TARGET_SIZE[1])
+    # # compute center offset
+    # x_center = (new_image_width - old_image_width) // 2
+    # y_center = (new_image_height - old_image_height) // 2
+
+    # try:
+    #     # copy img image into center of result image
+    #     result[y_center:y_center+old_image_height,
+    #            x_center:x_center+old_image_width] = img
+    # except:
+    #     ## AN ALTERNATIVE WAY - DO NOT REMOVE
+    #     # sf = np.minimum(new_image_width/old_image_width,new_image_height/old_image_height)
+    #     # if channels>0:
+    #     #     img = rescale(img,(sf,sf,1),anti_aliasing=True, preserve_range=True, order=1)
+    #     # else:
+    #     #     img = rescale(img,(sf,sf),anti_aliasing=True, preserve_range=True, order=1)
+    #     # if channels>0:
+    #     #     old_image_height, old_image_width, channels = img.shape
+    #     # else:
+    #     #     old_image_height, old_image_width = img.shape
+    #     #
+    #     # x_center = (new_image_width - old_image_width) // 2
+    #     # y_center = (new_image_height - old_image_height) // 2
+    #     #
+    #     # result[y_center:y_center+old_image_height,
+    #     #        x_center:x_center+old_image_width] = img.astype('uint8')
+    #     if channels>0:
+    #         result = scale_rgb(img,TARGET_SIZE[0],TARGET_SIZE[1],3)
+    #     else:
+    #         result = scale(img,TARGET_SIZE[0],TARGET_SIZE[1])
 
     wend = f.split(os.sep)[-2]
     fdir = os.path.dirname(f)
-    fdirout = fdir.replace(wend,'padded_'+wend)
+    # fdirout = fdir.replace(wend,'padded_'+wend)
+    fdirout = fdir.replace(wend,'resized_'+wend)
+
     # save result
     imsave(fdirout+os.sep+f.split(os.sep)[-1].replace('.jpg','.png'), result.astype('uint8'), check_contrast=False, compression=0)
 
@@ -285,90 +294,85 @@ else:
 
 szs = np.vstack(szs)[:,0]
 
-do_resize = True
+# do_resize = True
 # if len(np.unique(szs))>1:
 #     do_resize=True
 # else:
 #     do_resize=False
 
 ## rersize / pad imagery so all a consistent size (TARGET_SIZE)
-if do_resize:
+# if do_resize:
 
-    ## make padded direcs
-    for w in W:
-        wend = w.split('/')[-1]
-        print(wend)
-        newdirec = w.replace(wend,'padded_'+wend)
-        try:
-            os.mkdir(newdirec)
-        except:
-            pass
+## make padded direcs
+for w in W:
+    wend = w.split('/')[-1]
+    # print(wend)
+    # newdirec = w.replace(wend,'padded_'+wend)
+    newdirec = w.replace(wend,'resized_'+wend)
 
-    if USEMASK:
-        newdireclabels = label_data_path.replace('mask','padded_mask')
-    else:
-        newdireclabels = label_data_path.replace('label','padded_label')
     try:
-        os.mkdir(newdireclabels)
+        os.mkdir(newdirec)
     except:
         pass
 
+if USEMASK:
+    # newdireclabels = label_data_path.replace('mask','padded_mask')
+    newdireclabels = label_data_path.replace('mask','resized_mask')
+else:
+    # newdireclabels = label_data_path.replace('label','padded_label')
+    newdireclabels = label_data_path.replace('label','resized_label')
+try:
+    os.mkdir(newdireclabels)
+except:
+    pass
 
-    if len(W)==1:
-        try:
-            w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_image)(os.path.normpath(f), TARGET_SIZE) for f in files)
-        except:
-            w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_image)(os.path.normpath(f), TARGET_SIZE) for f in files.squeeze())
 
-        w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_label)(os.path.normpath(lfile), TARGET_SIZE) for lfile in label_files)
+if len(W)==1:
+    try:
+        w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_image)(os.path.normpath(f), TARGET_SIZE) for f in files)
+    except:
+        w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_image)(os.path.normpath(f), TARGET_SIZE) for f in files.squeeze())
 
-    else:
-        ## cycle through, merge and padd/resize if need to
-        for file,lfile in zip(files, label_files):
+    w = Parallel(n_jobs=-2, verbose=0, max_nbytes=None)(delayed(do_pad_label)(os.path.normpath(lfile), TARGET_SIZE) for lfile in label_files)
 
-            for f in file:
-                do_pad_image(f, TARGET_SIZE)
-            do_pad_label(lfile, TARGET_SIZE)
+else:
+    ## cycle through, merge and padd/resize if need to
+    for file,lfile in zip(files, label_files):
+
+        for f in file:
+            do_pad_image(f, TARGET_SIZE)
+        do_pad_label(lfile, TARGET_SIZE)
 
 
 ## write padded labels to file
-if do_resize:
-    label_data_path = newdireclabels #label_data_path.replace('labels','padded_labels')
+# if do_resize:
+label_data_path = newdireclabels #label_data_path.replace('labels','padded_labels')
 
-    label_files = natsorted(glob(label_data_path+os.sep+'*.png'))
-    if len(label_files)<1:
-        label_files = natsorted(glob(label_data_path+os.sep+'images'+os.sep+'*.png'))
-    print("{} label files".format(len(label_files)))
+label_files = natsorted(glob(label_data_path+os.sep+'*.png'))
+if len(label_files)<1:
+    label_files = natsorted(glob(label_data_path+os.sep+'images'+os.sep+'*.png'))
+print("{} label files".format(len(label_files)))
 
-    W2 = []
-    for w in W:
-        wend = os.path.normpath(w).split(os.sep)[-1]
-        w = w.replace(wend,'padded_'+wend)
-        W2.append(w)
-    W = W2
-    del W2
+W2 = []
+for w in W:
+    wend = os.path.normpath(w).split(os.sep)[-1]
+    # w = w.replace(wend,'padded_'+wend)
+    w = w.replace(wend,'resized_'+wend)
+    W2.append(w)
+W = W2
+del W2
 
-    files = []
-    for data_path in W:
-        f = natsorted(glob(os.path.normpath(data_path)+os.sep+'*.png'))
-        if len(f)<1:
-            f = natsorted(glob(os.path.normpath(data_path)+os.sep+'images'+os.sep+'*.png'))
-        files.append(f)
+files = []
+for data_path in W:
+    f = natsorted(glob(os.path.normpath(data_path)+os.sep+'*.png'))
+    if len(f)<1:
+        f = natsorted(glob(os.path.normpath(data_path)+os.sep+'images'+os.sep+'*.png'))
+    files.append(f)
 
-    # number of bands x number of samples
-    files = np.vstack(files).T
-    print("{} sets of {} image files".format(len(W),len(files)))
+# number of bands x number of samples
+files = np.vstack(files).T
+print("{} sets of {} image files".format(len(W),len(files)))
 
-# else:
-
-#     label_files = natsorted(glob(os.path.normpath(label_data_path)+os.sep+'*.jpg'))
-#     if len(label_files)<1:
-#         label_files = natsorted(glob(os.path.normpath(label_data_path)+os.sep+'images'+os.sep+'*.jpg'))
-#     print("{} label files".format(len(label_files)))
-
-#     files = natsorted(glob(os.path.normpath(data_path)+os.sep+'*.jpg'))
-#     if len(files)<1:
-#         files = natsorted(glob(os.path.normpath(data_path)+os.sep+'images'+os.sep+'*.jpg'))
 
 ###================================================
 
@@ -551,7 +555,7 @@ for imgs,lbls,files in dataset.take(100):
          plt.imshow(im)
 
      lab = np.argmax(lab.numpy().squeeze(),-1)
-     print(lab.shape)
+    #  print(lab.shape)
 
      color_label = label_to_colors(np.squeeze(lab), tf.cast(im[:,:,0]==0,tf.uint8),
                                     alpha=128, colormap=class_label_colormap,

--- a/seg_images_in_folder.py
+++ b/seg_images_in_folder.py
@@ -159,6 +159,8 @@ for counter,weights in enumerate(W):
 
     #from imports import *
     from doodleverse_utils.imports import *
+    from doodleverse_utils.model_imports import *
+
     #---------------------------------------------------
 
     #=======================================================
@@ -257,7 +259,7 @@ for counter,weights in enumerate(W):
     except:
         # Load the metrics mean_iou, dice_coef from doodleverse_utils
         # Load in the custom loss function from doodleverse_utils        
-        model.compile(optimizer = 'adam', loss = dice_coef_loss(NCLASSES), metrics = [iou_multi(NCLASSES), dice_multi(NCLASSES)])
+        model.compile(optimizer = 'adam', loss = dice_coef_loss(NCLASSES))#, metrics = [iou_multi(NCLASSES), dice_multi(NCLASSES)])
 
         model.load_weights(weights)
 
@@ -299,6 +301,8 @@ if not 'TESTTIMEAUG' in locals():
 #look for do_crf in config
 if not 'do_crf' in locals():
     do_crf = False
+if not 'WRITE_MODELMETADATA' in locals():
+    WRITE_MODELMETADATA = False
 
 # Import do_seg() from doodleverse_utils to perform the segmentation on the images
 for f in tqdm(sample_filenames):

--- a/train_model.py
+++ b/train_model.py
@@ -29,7 +29,6 @@ from tkinter import filedialog
 from tkinter import *
 from random import shuffle
 import pandas as pd
-# import tensorflow_addons as tfa
 
 ###############################################################
 ## VARIABLES
@@ -225,6 +224,7 @@ def read_seg_dataset_multiclass(example):
 
     return image, label
 
+
 #-----------------------------------
 def plotcomp_n_metrics(ds,model,NCLASSES, DOPLOT, test_samples_fig, subset,num_batches=20):
 
@@ -268,9 +268,9 @@ def plotcomp_n_metrics(ds,model,NCLASSES, DOPLOT, test_samples_fig, subset,num_b
             P.append(out['Precision'])
             MCC.append(out['MatthewsCorrelationCoefficient'])
 
-            iouscore = mean_iou_np(tf.expand_dims(tf.squeeze(lbl), 0), est_label)
+            iouscore = mean_iou_np(tf.expand_dims(tf.squeeze(lbl), 0), est_label, NCLASSES)
 
-            dicescore = mean_dice_np(tf.expand_dims(tf.squeeze(lbl), 0), est_label)
+            dicescore = mean_dice_np(tf.expand_dims(tf.squeeze(lbl), 0), est_label, NCLASSES)
 
             kl = tf.keras.losses.KLDivergence() #initiate object
 
@@ -768,6 +768,31 @@ print('Mean of Matthews Correlation Coefficients (validation subset)={mean_dice:
 print('Mean of mean Dice scores (validation subset)={mean_dice:0.3f}'.format(mean_dice=np.mean(Dc)))
 print('Mean of mean KLD scores (validation subset)={mean_kld:0.3f}'.format(mean_kld=np.mean(Kc)))
 
+## uncomment to see comparison plot of validation metrics
+# plt.figure(figsize=(10,10))
+# plt.subplots_adjust(hspace=0.3, wspace=0.3)
+# plt.subplot(321)
+# plt.plot(IOUc,MIOU,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean IOU (Confusion Matrix)')
+
+# plt.subplot(322)
+# plt.plot(IOUc,FWIOU,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean Frequency-weighted IOU (Confusion Matrix)')
+
+# plt.subplot(323)
+# plt.plot(IOUc,MCC,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('Matthews Correlation Coefficient (Confusion Matrix)')
+
+# plt.subplot(324)
+# plt.plot(IOUc,Dc,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean Dice')
+
+# plt.subplot(325)
+# plt.plot(IOUc,Kc,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean K-L divergence')
+
+# plt.savefig('tmp3.png', dpi=200); plt.close()
+
 
 IOUc, Dc, Kc, OA, MIOU, FWIOU, MCC = plotcomp_n_metrics(
                                 train_ds,model,NCLASSES,DOPLOT,test_samples_fig,'train')
@@ -777,3 +802,29 @@ print('Mean of mean frequency weighted IoUs, confusion matrix (train subset)={me
 print('Mean of Matthews Correlation Coefficients (train subset)={mean_dice:0.3f}'.format(mean_dice=np.mean(MCC)))
 print('Mean of mean Dice scores (train subset)={mean_dice:0.3f}'.format(mean_dice=np.mean(Dc)))
 print('Mean of mean KLD scores (train subset)={mean_kld:0.3f}'.format(mean_kld=np.mean(Kc)))
+
+## uncomment to see comparison plot of validation metrics
+
+# plt.figure(figsize=(10,10))
+# plt.subplots_adjust(hspace=0.3, wspace=0.3)
+# plt.subplot(321)
+# plt.plot(IOUc,MIOU,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean IOU (Confusion Matrix)')
+
+# plt.subplot(322)
+# plt.plot(IOUc,FWIOU,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean Frequency-weighted IOU (Confusion Matrix)')
+
+# plt.subplot(323)
+# plt.plot(IOUc,MCC,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('Matthews Correlation Coefficient (Confusion Matrix)')
+
+# plt.subplot(324)
+# plt.plot(IOUc,Dc,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean Dice')
+
+# plt.subplot(325)
+# plt.plot(IOUc,Kc,'.')
+# plt.xlabel('mean IOU'); plt.ylabel('mean K-L divergence')
+
+# plt.savefig('tmp2.png', dpi=200); plt.close()

--- a/train_model.py
+++ b/train_model.py
@@ -29,7 +29,7 @@ from tkinter import filedialog
 from tkinter import *
 from random import shuffle
 import pandas as pd
-import tensorflow_addons as tfa
+# import tensorflow_addons as tfa
 
 ###############################################################
 ## VARIABLES
@@ -454,6 +454,13 @@ val_ds = val_ds.map(read_seg_dataset_multiclass, num_parallel_calls=AUTO)
 val_ds = val_ds.repeat()
 val_ds = val_ds.batch(BATCH_SIZE, drop_remainder=True) # drop_remainder will be needed on TPU
 val_ds = val_ds.prefetch(AUTO) #
+
+### find NCLASSES
+for counter, (imgs,lbls) in enumerate(train_ds.take(1)):
+    for count,(im,lab) in enumerate(zip(imgs, lbls)):
+        NCLASSES = lab.shape[-1]
+print('Number of classes = {}'.format(NCLASSES))
+
 
 ### the following code is for troubleshooting, when do_viz=True
 do_viz = False 


### PR DESCRIPTION
This PR replaces https://github.com/Doodleverse/segmentation_gym/pull/87

The update does 3 things

1. in `makedatasets`, it creates resized imagery. Previously, imagery was padded if smaller than target size. Now, imagery is resized
2. in `train model`, mean IoU and mean Dice metrics used in model evaluation are now the same as those used in model training
3. in `seg_images`, and `batch_seg_images`, a bug is fix if optional config inputs are not specified. TESTTIMEAUG defaults to false, do_crf defaults to False

This corresponds with doodleverse-utils version 0.0.8, which implements the following change

1. in `do_seg`, from doodleverse-utils/prediction imports, when NCLASSES>1, and when do_crf is False, the proper behaviour is implemented, which is a simple argmax to create the label from the softmax stack